### PR TITLE
Add Device diagnostics to test runner

### DIFF
--- a/runner/android/config/settings.yml
+++ b/runner/android/config/settings.yml
@@ -57,7 +57,7 @@ test:
 
     android:
       uptime:
-        reboot_timeout: 86400 # 24hrs
+        reboot_timeout: 10800 # 3hrs
 
       # Tests will stop running if the following conditions are meet
       battery:

--- a/runner/ios/config/settings.yml
+++ b/runner/ios/config/settings.yml
@@ -54,3 +54,14 @@ test:
     hive:
       load_warning: 0.7
       load_error: 1.5
+
+    ios:
+      uptime:
+        reboot_timeout: 10800 # 3hrs
+
+      # Tests will stop running if the following conditions are meet
+      # Currently not implemented
+      battery:
+        # level: 20        # > 20%
+        # temperature: 320 # < 32°C
+        # voltage: 4600    # < 4600mV


### PR DESCRIPTION
Why:

* When the device is stuck after running UI tests the device needs to
be rebooted

This change addresses the need by:

* Reboot devices every 3 hours